### PR TITLE
Await SSH tunnel init using docker exec

### DIFF
--- a/docker_push_ssh/cli.py
+++ b/docker_push_ssh/cli.py
@@ -38,12 +38,17 @@ def waitForSshTunnelInit(retries=20, delay=1.0):
     for _ in range(retries):
         time.sleep(delay)
 
-        try:
-            response = urllib2.urlopen("http://localhost:5000/v2/", timeout=5)
-        except (socket.error, urllib2.URLError, httplib.BadStatusLine):
-            continue
+        sshCheckCommandResult = Command("docker", [
+            "exec",
+            "docker-push-ssh-tunnel",
+            "wget",
+            "-O", "/dev/null",
+            "-q",
+            "--timeout=5",
+            "http://localhost:5000/v2"
+        ]).environment_dict(os.environ).execute()
 
-        if response.getcode() == 200:
+        if not sshCheckCommandResult.failed():
             return True
 
     return False


### PR DESCRIPTION
This change is from a different pull-request that was never finished. It adds a 5-second timeout to the wget command as requested in that PR.

https://github.com/brthor/docker-push-ssh/pull/10